### PR TITLE
Update quadratic damping coefficients

### DIFF
--- a/models/bluerov2/model.sdf
+++ b/models/bluerov2/model.sdf
@@ -85,12 +85,12 @@
       <mQ>0</mQ>
       <nR>0</nR>
       <!-- Second order stability derivative: -->
-      <xUU>-33.800000000000004</xUU>
-      <yVV>-54.26875</yVV>
-      <zWW>-73.37135</zWW>
-      <kPP>-4.0</kPP>
-      <mQQ>-4.0</mQQ>
-      <nRR>-4.0</nRR>
+      <xUabsU>-33.800000000000004</xUabsU>
+      <yVabsV>-54.26875</yVabsV>
+      <zWabsW>-73.37135</zWabsW>
+      <kPabsP>-4.0</kPabsP>
+      <mQabsQ>-4.0</mQabsQ>
+      <nRabsR>-4.0</nRabsR>
     </plugin>
 
     <link name="thruster1">


### PR DESCRIPTION
This PR changes the parameter name for the quadratic damping coefficients as a result of changes to the gz-sim7 hydrodynamics plugin made in https://github.com/gazebosim/gz-sim/commit/fde6ec608bbd1679178c70c62bdc08db41eb38d6. These changes are in releases gz-sim7_7.2.0 and gz-sim7_7.3.0.

### Details

- To retain the previous behaviour the second order stability derivative parameters (quadratic damping) require name changes: `<xUabsU>` becomes `<xUabsU>` etc.

### See also:

- https://github.com/gazebosim/gz-sim/issues/1871
- https://github.com/ArduPilot/ardupilot_gazebo/issues/45