### PR TITLE
Small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ model in Gazebo:
 
 ~~~bash
 cd ~/colcon_ws/src/bluerov2_ignition
-. scripts/cw.sh <model_name>
-. scripts/stop.sh <model_name>
+scripts/cw.sh <model_name>
+scripts/stop.sh <model_name>
 ~~~
 
 where `<model_name>` is replaced with the corresponding model defined in the world (i.e.,

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Tools/autotest/sim_vehicle.py -L RATBeach -v ArduSub -f <frame> --model=JSON --o
 where `<frame>` is replaced with either `vectored` for the BlueROV2 base configuration or
 `vectored_6dof` for the BlueROV2 Heavy configuration.
 
+Note: if you run into problems switching between the vectored and vectored_6dof frame add the `-w` option to delete all ArduSub parameters.
+
 Use MAVProxy to send commands to ArduSub:
 
 ~~~bash

--- a/models/bluerov2/model.sdf
+++ b/models/bluerov2/model.sdf
@@ -54,7 +54,7 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
       <link_name>base_link</link_name>
-      <water_density>1000.0</water_density>
+      <water_density>998.0</water_density>
       <!-- Added mass: -->
       <xDotU>0</xDotU>
       <yDotV>0</yDotV>
@@ -70,12 +70,12 @@
       <mQ>0</mQ>
       <nR>0</nR>
       <!-- Second order stability derivative: -->
-      <xUabsU>-33.8</xUabsU>
-      <yVabsV>-54.269</yVabsV>
-      <zWabsW>-73.371</zWabsW>
-      <kPabsP>-4.0</kPabsP>
-      <mQabsQ>-4.0</mQabsQ>
-      <nRabsR>-4.0</nRabsR>
+      <xUabsU>-33.732</xUabsU>
+      <yVabsV>-54.16</yVabsV>
+      <zWabsW>-73.225</zWabsW>
+      <kPabsP>-3.992</kPabsP>
+      <mQabsQ>-3.992</mQabsQ>
+      <nRabsR>-3.992</nRabsR>
     </plugin>
 
     <link name="thruster1">
@@ -84,7 +84,7 @@
         <pose>0 0 0 -1.571 0 0</pose>
         <geometry>
           <mesh>
-            <uri>model://bluerov2_heavy/meshes/t200_ccw_prop.dae</uri>
+            <uri>model://bluerov2/meshes/t200_ccw_prop.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -107,7 +107,7 @@
         <pose>0 0 0 -1.571 0 0</pose>
         <geometry>
           <mesh>
-            <uri>model://bluerov2_heavy/meshes/t200_ccw_prop.dae</uri>
+            <uri>model://bluerov2/meshes/t200_ccw_prop.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -130,7 +130,7 @@
         <pose>0 0 0 1.571 0 0</pose>
         <geometry>
           <mesh>
-            <uri>model://bluerov2_heavy/meshes/t200_cw_prop.dae</uri>
+            <uri>model://bluerov2/meshes/t200_cw_prop.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -153,7 +153,7 @@
         <pose>0 0 0 1.571 0 0</pose>
         <geometry>
           <mesh>
-            <uri>model://bluerov2_heavy/meshes/t200_cw_prop.dae</uri>
+            <uri>model://bluerov2/meshes/t200_cw_prop.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -176,7 +176,7 @@
         <pose>0 0 0 -1.571 0 1.571</pose>
         <geometry>
           <mesh>
-            <uri>model://bluerov2_heavy/meshes/t200_ccw_prop.dae</uri>
+            <uri>model://bluerov2/meshes/t200_ccw_prop.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -199,7 +199,7 @@
         <pose>0 0 0 1.571 0 1.571</pose>
         <geometry>
           <mesh>
-            <uri>model://bluerov2_heavy/meshes/t200_cw_prop.dae</uri>
+            <uri>model://bluerov2/meshes/t200_cw_prop.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -270,7 +270,7 @@
       <namespace>bluerov2</namespace>
       <joint_name>thruster1_joint</joint_name>
       <thrust_coefficient>0.02</thrust_coefficient>
-      <fluid_density>1000.0</fluid_density>
+      <fluid_density>998.0</fluid_density>
       <propeller_diameter>0.1</propeller_diameter>
       <velocity_control>true</velocity_control>
       <use_angvel_cmd>False</use_angvel_cmd>
@@ -282,7 +282,7 @@
       <namespace>bluerov2</namespace>
       <joint_name>thruster2_joint</joint_name>
       <thrust_coefficient>0.02</thrust_coefficient>
-      <fluid_density>1000.0</fluid_density>
+      <fluid_density>998.0</fluid_density>
       <propeller_diameter>0.1</propeller_diameter>
       <velocity_control>true</velocity_control>
       <use_angvel_cmd>False</use_angvel_cmd>
@@ -295,7 +295,7 @@
       <joint_name>thruster3_joint</joint_name>
       <!-- Reverse spin to balance torque -->
       <thrust_coefficient>-0.02</thrust_coefficient>
-      <fluid_density>1000.0</fluid_density>
+      <fluid_density>998.0</fluid_density>
       <propeller_diameter>0.1</propeller_diameter>
       <velocity_control>true</velocity_control>
       <use_angvel_cmd>False</use_angvel_cmd>
@@ -308,7 +308,7 @@
       <joint_name>thruster4_joint</joint_name>
       <!-- Reverse spin to balance torque -->
       <thrust_coefficient>-0.02</thrust_coefficient>
-      <fluid_density>1000.0</fluid_density>
+      <fluid_density>998.0</fluid_density>
       <propeller_diameter>0.1</propeller_diameter>
       <velocity_control>true</velocity_control>
       <use_angvel_cmd>False</use_angvel_cmd>
@@ -320,7 +320,7 @@
       <namespace>bluerov2</namespace>
       <joint_name>thruster5_joint</joint_name>
       <thrust_coefficient>0.02</thrust_coefficient>
-      <fluid_density>1000.0</fluid_density>
+      <fluid_density>998.0</fluid_density>
       <propeller_diameter>0.1</propeller_diameter>
       <velocity_control>true</velocity_control>
       <use_angvel_cmd>False</use_angvel_cmd>
@@ -333,7 +333,7 @@
       <joint_name>thruster6_joint</joint_name>
       <!-- Reverse spin to balance torque -->
       <thrust_coefficient>-0.02</thrust_coefficient>
-      <fluid_density>1000.0</fluid_density>
+      <fluid_density>998.0</fluid_density>
       <propeller_diameter>0.1</propeller_diameter>
       <velocity_control>true</velocity_control>
       <use_angvel_cmd>False</use_angvel_cmd>

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -11,3 +11,8 @@ gz topic -t /model/$1/joint/thruster3_joint/cmd_thrust -m gz.msgs.Double -p 'dat
 gz topic -t /model/$1/joint/thruster4_joint/cmd_thrust -m gz.msgs.Double -p 'data: 0'
 gz topic -t /model/$1/joint/thruster5_joint/cmd_thrust -m gz.msgs.Double -p 'data: 0'
 gz topic -t /model/$1/joint/thruster6_joint/cmd_thrust -m gz.msgs.Double -p 'data: 0'
+
+if [ "$1" = "bluerov2_heavy" ]; then
+   gz topic -t /model/$1/joint/thruster7_joint/cmd_thrust -m gz.msgs.Double -p 'data: 0'
+   gz topic -t /model/$1/joint/thruster8_joint/cmd_thrust -m gz.msgs.Double -p 'data: 0'
+fi


### PR DESCRIPTION
A few changes to the recent PRs:
* stop thrusters 7 and 8 in stop.sh
* re-ran generate_model.py, there were changes in bluerov2/model.sdf
* use of exit in various .sh files means we need to call, not source
* added a note in the README to add the `-w` option to wipe parameters. Fixed a problem I saw where thruster 8 was not responding.