### PR TITLE
Position aft thrusters symmetrically with fwd thrusters

### DIFF
--- a/models/bluerov2/configs.yaml
+++ b/models/bluerov2/configs.yaml
@@ -22,10 +22,10 @@ thrusters:
   - x: 0.14 # Thruster 2
     y: 0.092
     z: 0.0
-  - x: -0.15 # Thruster 3
+  - x: -0.14 # Thruster 3
     y: -0.092
     z: 0.0
-  - x: -0.15 # Thruster 4
+  - x: -0.14 # Thruster 4
     y: 0.092
     z: 0.0
   - x: 0.0 # Thruster 5

--- a/models/bluerov2/model.sdf
+++ b/models/bluerov2/model.sdf
@@ -125,7 +125,7 @@
     </link>
 
     <link name="thruster3">
-      <pose>-0.15 -0.092 0.0 -1.571 1.571 0.785</pose>
+      <pose>-0.14 -0.092 0.0 -1.571 1.571 0.785</pose>
       <visual name="thruster_prop_visual">
         <pose>0 0 0 1.571 0 0</pose>
         <geometry>
@@ -148,7 +148,7 @@
     </link>
 
     <link name="thruster4">
-      <pose>-0.15 0.092 0.0 -1.571 1.571 2.356</pose>
+      <pose>-0.14 0.092 0.0 -1.571 1.571 2.356</pose>
       <visual name="thruster_prop_visual">
         <pose>0 0 0 1.571 0 0</pose>
         <geometry>

--- a/models/bluerov2_heavy/configs.yaml
+++ b/models/bluerov2_heavy/configs.yaml
@@ -25,10 +25,10 @@ thrusters:
   - x: 0.14 # Thruster 2
     y: 0.092
     z: 0.0
-  - x: -0.15 # Thruster 3
+  - x: -0.14 # Thruster 3
     y: -0.092
     z: 0.0
-  - x: -0.15 # Thruster 4
+  - x: -0.14 # Thruster 4
     y: 0.092
     z: 0.0
   - x: 0.118 # Thruster 5

--- a/models/bluerov2_heavy/model.sdf
+++ b/models/bluerov2_heavy/model.sdf
@@ -125,7 +125,7 @@
     </link>
 
     <link name="thruster3">
-      <pose>-0.15 -0.092 0.0 -1.571 1.571 0.785</pose>
+      <pose>-0.14 -0.092 0.0 -1.571 1.571 0.785</pose>
       <visual name="thruster_prop_visual">
         <pose>0 0 0 1.571 0 0</pose>
         <geometry>
@@ -148,7 +148,7 @@
     </link>
 
     <link name="thruster4">
-      <pose>-0.15 0.092 0.0 -1.571 1.571 2.356</pose>
+      <pose>-0.14 0.092 0.0 -1.571 1.571 2.356</pose>
       <visual name="thruster_prop_visual">
         <pose>0 0 0 1.571 0 0</pose>
         <geometry>


### PR DESCRIPTION
Position aft thrusters symmetrically with forward thrusters along the X-axis for both the standard and heavy configurations of the ROV. Fixes #16 and allows for idealized motion during yaw and sway maneuvers.