### PR TITLE
Fix gazebo/ardupilot y-axis mapping direction

### DIFF
--- a/models/bluerov2_heavy/model.sdf
+++ b/models/bluerov2_heavy/model.sdf
@@ -435,7 +435,7 @@
 
       <!-- Transform from the Gazebo body frame (x-forward, y-left, z-up)
            to the ArduPilot body frame (x-forward, y-right, z-down) -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.142 0 0</modelXYZToAirplaneXForwardZDown>
+      <modelXYZToAirplaneXForwardZDown>0 1.571 0 3.142 0 0</modelXYZToAirplaneXForwardZDown>
 
       <!-- Transform from the Gazebo world frame (ENU)
            to the ArduPilot world frame (NED) -->


### PR DESCRIPTION
Hi Clyde! 
The y-axis is flipped in the bluerov-heavy model, not sure if it is an issue for the bluerov as well. 
The patch ensures the gazebo sim controls match the real robot config